### PR TITLE
Added setting of binding properties individually for each model property...

### DIFF
--- a/tests/BindingTests.fs
+++ b/tests/BindingTests.fs
@@ -51,3 +51,116 @@ let modelWithOptionFields() =
     model.X <- Some 42
     Assert.Equal<string>( "42", textBox.Text)
 
+
+module BindingOptionTests =
+    open BindingOptions
+    [<Fact>]
+    let mode() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> Mode BindingMode.OneTime @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(BindingMode.OneTime, binding.Mode)
+
+    [<Fact>]
+    let oneWay() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> OneWay @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(BindingMode.OneWay, binding.Mode)
+
+    [<Fact>]
+    let updateSource() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> UpdateSource UpdateSourceTrigger.Explicit @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(UpdateSourceTrigger.Explicit, binding.UpdateSourceTrigger)
+
+    [<Fact>]
+    let updateSourceOnChange() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> UpdateSourceOnChange @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(UpdateSourceTrigger.PropertyChanged, binding.UpdateSourceTrigger)
+
+    [<Fact>]
+    let fallbackValue() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        let fallback = box "foo"
+        Binding.OfExpression <@ textBox.Text <- model.Value |> FallbackValue fallback @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(fallback, binding.FallbackValue)
+
+    [<Fact>]
+    let targetNullValue() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        let nullValue = box "nothing"
+        Binding.OfExpression <@ textBox.Text <- model.Value |> TargetNullValue nullValue @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(nullValue, binding.TargetNullValue)
+
+    // Note: all ..._True and ..._False tests can be replaced with Xunit Theory+true/false parameters
+    // when upgraded to Xunit 2.x.
+    [<Fact>]
+    let validatesOnDataErrors_True() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> ValidatesOnDataErrors true @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(true, binding.ValidatesOnDataErrors)
+
+    [<Fact>]
+    let validatesOnDataErrors_False() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> ValidatesOnDataErrors false @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(false, binding.ValidatesOnDataErrors)
+
+    [<Fact>]
+    let validatesOnExceptions_True() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> ValidatesOnExceptions true @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(true, binding.ValidatesOnExceptions)
+
+    [<Fact>]
+    let validatesOnExceptions_False() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression <@ textBox.Text <- model.Value |> ValidatesOnExceptions false @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(false, binding.ValidatesOnExceptions)
+
+    [<Fact>]
+    let multipleOptions() = 
+        let textBox = TextBox()
+        let model: MyModel = MyModel.Create()
+        textBox.DataContext <- model
+        Binding.OfExpression 
+            <@ 
+                textBox.Text <- model.Value 
+                                |> Mode BindingMode.OneTime
+                                |> UpdateSourceOnChange
+                                |> ValidatesOnExceptions false 
+            @>
+        let binding = textBox.GetBindingExpression(TextBox.TextProperty).ParentBinding
+        Assert.Equal(BindingMode.OneTime, binding.Mode)
+        Assert.Equal(UpdateSourceTrigger.PropertyChanged, binding.UpdateSourceTrigger)
+        Assert.Equal(false, binding.ValidatesOnExceptions)


### PR DESCRIPTION
I've added the possibility to specify binding properties for individual model properties like this:
```
    <@
      view.Root.LastName.Text <- model.LastName |> UpdateSourceOnChange
      view.Root.Bitness.Text  <- model.Bitness |> OneWay
    @>
```

It's described in detail in this blog post:
http://blog.wezeku.com/2013/07/10/adding-binding-options-to-morozovs-wpf-mvc-framework/

I mailed Dmitry about it when I coded it, and since the MVC framework is productized now, I've made a pull req with my changes. I hope this may be of interest for the MVC project!