### PR TITLE
Corrected references in generate.fsx; fixes #19

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -23,10 +23,10 @@ let info =
 // --------------------------------------------------------------------------------------
 
 #I "../../packages/FSharp.Formatting/lib/net40"
-#I "../../packages/RazorEngine/lib/net40"
 #I "../../packages/FSharp.Compiler.Service/lib/net40"
-#r "../../packages/Microsoft.AspNet.Razor/lib/net40/System.Web.Razor.dll"
+#I "../../packages/FSharpVSPowerTools.Core/lib/net45"
 #r "../../packages/FAKE/tools/FakeLib.dll"
+#r "System.Web.Razor.dll"
 #r "RazorEngine.dll"
 #r "FSharp.Literate.dll"
 #r "FSharp.CodeFormat.dll"


### PR DESCRIPTION
`RazorEngine.dll` and `System.Web.Razor.dll` are included in `FSharp.Formatting`, so there are no packages explicitly installed for those. Also, an `#I` directive for `FSharpVSPowerTools.Core` was missing.

After correcting those references, the `GenerateDocs` target now runs without error.

This fixes #19.

The Travis build is failing, but as that is apparently for Mono, it will *have* to, lacking the WPF assemblies.